### PR TITLE
Added Icon size and separation setting & elevated max shortcuts per group

### DIFF
--- a/backgroundClient/Classes/Category.cs
+++ b/backgroundClient/Classes/Category.cs
@@ -21,6 +21,8 @@ namespace backgroundClient.Classes
         public int Width; // not used aon
         public double Opacity = 10;
         public String HoverColor;
+        public int IconSize = 50;
+        public int Separation = 8;
 
         Regex specialCharRegex = new Regex("[*'\",_&#^@]");
 
@@ -64,6 +66,8 @@ namespace backgroundClient.Classes
                 this.Opacity = category.Opacity;
                 this.allowOpenAll = category.allowOpenAll;
                 this.HoverColor = category.HoverColor;
+                this.IconSize = category.IconSize;
+                this.Separation = category.Separation;
             }
 
         }

--- a/backgroundClient/Classes/LoadedCategory.cs
+++ b/backgroundClient/Classes/LoadedCategory.cs
@@ -19,6 +19,8 @@ namespace backgroundClient.Classes
         public string ColorString = System.Drawing.ColorTranslator.ToHtml(Color.FromArgb(31, 31, 31));
         public Icon groupIco;
         public string Name;
+        public int IconSize;
+        public int Separation;
 
         public String HoverColor;
 
@@ -33,6 +35,8 @@ namespace backgroundClient.Classes
             Name = newCat.Name;
             allowOpenAll = newCat.allowOpenAll;
             Opacity = newCat.Opacity;
+            IconSize = newCat.IconSize;
+            Separation = newCat.Separation;
 
             foreach (ProgramShortcut psc in programShortcuts)
             {

--- a/backgroundClient/Forms/frmMain.cs
+++ b/backgroundClient/Forms/frmMain.cs
@@ -52,8 +52,9 @@ namespace backgroundClient
 
         private Jumplist jumpList;
 
-        public int ucShortcutHeight;
-        public int ucShortcutWidth;
+        public int ucShortcutSize;
+        public int ucShortcutIconSize;
+        public int ucShortcutIconLocation;
 
         //------------------------------------------------------------------------------------
         // CTOR AND LOAD
@@ -385,10 +386,11 @@ namespace backgroundClient
         // Loading category and building shortcuts
         private void LoadCategory()
         {
-            this.Width = 0; 
-            this.Height = (int)(45 * xDpi);
-            ucShortcutHeight = this.Height;
-            ucShortcutWidth = (int)(55 * xDpi);
+            this.Width = 0;
+            this.Height = (int)((loadedCat.IconSize + loadedCat.Separation * 2) * xDpi);
+            ucShortcutSize = this.Height;
+            ucShortcutIconSize = (int)(loadedCat.IconSize * xDpi);
+            ucShortcutIconLocation = (int)(loadedCat.Separation * xDpi);
             int x = 0;
             int y = 0;
             int width = loadedCat.Width;
@@ -411,13 +413,13 @@ namespace backgroundClient
                 if (columns > width)  // creating new row if there are more psc than max width
                 {
                     x = 0;
-                    y += (int)(45 * xDpi);
-                    this.Height += (int)(45*xDpi);
+                    y += (int)((loadedCat.IconSize + loadedCat.Separation * 2) * xDpi);
+                    this.Height += (int)((loadedCat.IconSize + loadedCat.Separation * 2) * xDpi);
                     columns = 1;
                 }
 
-                if (this.Width < ((width * (int)(55 * xDpi))))
-                    this.Width += ((int)(55 * (xDpi)));
+                if (this.Width < ((width * (int)((loadedCat.IconSize + loadedCat.Separation * 2) * xDpi))))
+                    this.Width += ((int)((loadedCat.IconSize + loadedCat.Separation * 2) * (xDpi)));
 
                 // OLD
                 //BuildShortcutPanel(x, y, psc);
@@ -427,7 +429,8 @@ namespace backgroundClient
                 {
                     Psc = psc,
                     MotherForm = this,
-                    bkgImage = loadedCat.programImages[i]
+                    bkgImage = loadedCat.programImages[i],
+                    loadedCategory = loadedCat
                 };
                 pscPanel.Location = new System.Drawing.Point(x, y);
                 this.Controls.Add(pscPanel);
@@ -436,7 +439,7 @@ namespace backgroundClient
                 pscPanel.BringToFront();
 
                 // Reset values
-                x += (int)(55 * xDpi);
+                x += (int)((loadedCat.IconSize + loadedCat.Separation * 2) * xDpi);
                 columns++;
             }
 

--- a/backgroundClient/User Controls/ucShortcut.cs
+++ b/backgroundClient/User Controls/ucShortcut.cs
@@ -14,6 +14,7 @@ namespace backgroundClient.User_controls
         public ProgramShortcut Psc { get; set; }
         public frmMain MotherForm { get; set; }
         public Image bkgImage { get; set; }
+        public LoadedCategory loadedCategory { get; set; }
         public ucShortcut()
         {
             InitializeComponent();
@@ -21,13 +22,15 @@ namespace backgroundClient.User_controls
 
         private void ucShortcut_Load(object sender, EventArgs e)
         {
-            this.Size = new Size(MotherForm.ucShortcutWidth, MotherForm.ucShortcutHeight);
+            this.Size = new Size(MotherForm.ucShortcutSize, MotherForm.ucShortcutSize);
             this.Show();
             this.BringToFront();
             this.BackColor = MotherForm.BackColor;
             picIcon.BackgroundImage = bkgImage;
             toolTip1.SetToolTip(picIcon, Psc.name);
             toolTip1.SetToolTip(this, Psc.name);
+            picIcon.Location = new System.Drawing.Point(MotherForm.ucShortcutIconLocation, MotherForm.ucShortcutIconLocation);
+            picIcon.Size = new System.Drawing.Size(MotherForm.ucShortcutIconSize, MotherForm.ucShortcutIconSize);
         }
 
         public void ucShortcut_Click(object sender, EventArgs e)

--- a/main/Classes/Category.cs
+++ b/main/Classes/Category.cs
@@ -22,6 +22,8 @@ namespace client.Classes
         public int Width; // not used aon
         public double Opacity = 10;
         public String HoverColor;
+        public int IconSize = 50;
+        public int Separation = 8;
 
         Regex specialCharRegex = new Regex("[*'\",_&#^@]");
 
@@ -65,6 +67,8 @@ namespace client.Classes
                 this.Opacity = category.Opacity;
                 this.allowOpenAll = category.allowOpenAll;
                 this.HoverColor = category.HoverColor;
+                this.IconSize = category.IconSize;
+                this.Separation = category.Separation;
             }
 
         }

--- a/main/Forms/frmGroup.Designer.cs
+++ b/main/Forms/frmGroup.Designer.cs
@@ -46,9 +46,17 @@
             this.lblErrorShortcut = new System.Windows.Forms.Label();
             this.lblAddShortcut = new System.Windows.Forms.Label();
             this.pnlColor = new System.Windows.Forms.Panel();
+            this.IconSeparationText = new System.Windows.Forms.Label();
+            this.IconSeparationBottomButton = new System.Windows.Forms.Button();
+            this.lblIconSeparation = new System.Windows.Forms.Label();
+            this.IconSeparationTopButton = new System.Windows.Forms.Button();
+            this.IconSizeText = new System.Windows.Forms.Label();
+            this.IconSizeBottomButton = new System.Windows.Forms.Button();
             this.pnlCustomColor1 = new System.Windows.Forms.Panel();
             this.panel3 = new System.Windows.Forms.Panel();
+            this.lblIconSize = new System.Windows.Forms.Label();
             this.numOpacDown = new System.Windows.Forms.Button();
+            this.IconSizeTopButton = new System.Windows.Forms.Button();
             this.numOpacUp = new System.Windows.Forms.Button();
             this.lblPercent = new System.Windows.Forms.Label();
             this.pnlAllowOpenAll = new System.Windows.Forms.CheckBox();
@@ -338,8 +346,16 @@
             // 
             this.pnlColor.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.pnlColor.AutoSize = true;
+            this.pnlColor.Controls.Add(this.IconSeparationText);
+            this.pnlColor.Controls.Add(this.IconSeparationBottomButton);
+            this.pnlColor.Controls.Add(this.lblIconSeparation);
+            this.pnlColor.Controls.Add(this.IconSeparationTopButton);
+            this.pnlColor.Controls.Add(this.IconSizeText);
+            this.pnlColor.Controls.Add(this.IconSizeBottomButton);
             this.pnlColor.Controls.Add(this.pnlCustomColor1);
+            this.pnlColor.Controls.Add(this.lblIconSize);
             this.pnlColor.Controls.Add(this.numOpacDown);
+            this.pnlColor.Controls.Add(this.IconSizeTopButton);
             this.pnlColor.Controls.Add(this.numOpacUp);
             this.pnlColor.Controls.Add(this.lblPercent);
             this.pnlColor.Controls.Add(this.pnlAllowOpenAll);
@@ -352,8 +368,92 @@
             this.pnlColor.Controls.Add(this.radioLight);
             this.pnlColor.Location = new System.Drawing.Point(99, 578);
             this.pnlColor.Name = "pnlColor";
-            this.pnlColor.Size = new System.Drawing.Size(368, 164);
+            this.pnlColor.Size = new System.Drawing.Size(368, 275);
             this.pnlColor.TabIndex = 48;
+            // 
+            // IconSeparationText
+            // 
+            this.IconSeparationText.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.IconSeparationText.AutoSize = true;
+            this.IconSeparationText.BackColor = System.Drawing.Color.Transparent;
+            this.IconSeparationText.Font = new System.Drawing.Font("Segoe UI", 11.25F);
+            this.IconSeparationText.ForeColor = System.Drawing.Color.White;
+            this.IconSeparationText.Location = new System.Drawing.Point(67, 224);
+            this.IconSeparationText.Name = "IconSeparationText";
+            this.IconSeparationText.Size = new System.Drawing.Size(114, 20);
+            this.IconSeparationText.TabIndex = 57;
+            this.IconSeparationText.Text = "Icon separation:";
+            // 
+            // IconSeparationBottomButton
+            // 
+            this.IconSeparationBottomButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.IconSeparationBottomButton.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(31)))), ((int)(((byte)(31)))), ((int)(((byte)(31)))));
+            this.IconSeparationBottomButton.BackgroundImage = global::client.Properties.Resources.NumDownWhite;
+            this.IconSeparationBottomButton.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            this.IconSeparationBottomButton.FlatAppearance.BorderSize = 0;
+            this.IconSeparationBottomButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.IconSeparationBottomButton.Location = new System.Drawing.Point(314, 252);
+            this.IconSeparationBottomButton.Name = "IconSeparationBottomButton";
+            this.IconSeparationBottomButton.Size = new System.Drawing.Size(16, 8);
+            this.IconSeparationBottomButton.TabIndex = 59;
+            this.IconSeparationBottomButton.UseVisualStyleBackColor = false;
+            this.IconSeparationBottomButton.Click += new System.EventHandler(this.IconSeparationBottomButton_Click);
+            // 
+            // lblIconSeparation
+            // 
+            this.lblIconSeparation.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblIconSeparation.BackColor = System.Drawing.Color.Transparent;
+            this.lblIconSeparation.Font = new System.Drawing.Font("Segoe UI", 11.25F, System.Drawing.FontStyle.Bold);
+            this.lblIconSeparation.ForeColor = System.Drawing.Color.White;
+            this.lblIconSeparation.Location = new System.Drawing.Point(305, 224);
+            this.lblIconSeparation.Name = "lblIconSeparation";
+            this.lblIconSeparation.Size = new System.Drawing.Size(35, 25);
+            this.lblIconSeparation.TabIndex = 58;
+            this.lblIconSeparation.Text = "6";
+            this.lblIconSeparation.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // IconSeparationTopButton
+            // 
+            this.IconSeparationTopButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.IconSeparationTopButton.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(31)))), ((int)(((byte)(31)))), ((int)(((byte)(31)))));
+            this.IconSeparationTopButton.BackgroundImage = global::client.Properties.Resources.NumUpWhite;
+            this.IconSeparationTopButton.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            this.IconSeparationTopButton.FlatAppearance.BorderSize = 0;
+            this.IconSeparationTopButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.IconSeparationTopButton.Location = new System.Drawing.Point(314, 214);
+            this.IconSeparationTopButton.Name = "IconSeparationTopButton";
+            this.IconSeparationTopButton.Size = new System.Drawing.Size(16, 8);
+            this.IconSeparationTopButton.TabIndex = 60;
+            this.IconSeparationTopButton.UseVisualStyleBackColor = false;
+            this.IconSeparationTopButton.Click += new System.EventHandler(this.IconSeparationTopButton_Click);
+            // 
+            // IconSizeText
+            // 
+            this.IconSizeText.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.IconSizeText.AutoSize = true;
+            this.IconSizeText.BackColor = System.Drawing.Color.Transparent;
+            this.IconSizeText.Font = new System.Drawing.Font("Segoe UI", 11.25F);
+            this.IconSizeText.ForeColor = System.Drawing.Color.White;
+            this.IconSizeText.Location = new System.Drawing.Point(67, 167);
+            this.IconSizeText.Name = "IconSizeText";
+            this.IconSizeText.Size = new System.Drawing.Size(69, 20);
+            this.IconSizeText.TabIndex = 53;
+            this.IconSizeText.Text = "Icon size:";
+            // 
+            // IconSizeBottomButton
+            // 
+            this.IconSizeBottomButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.IconSizeBottomButton.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(31)))), ((int)(((byte)(31)))), ((int)(((byte)(31)))));
+            this.IconSizeBottomButton.BackgroundImage = global::client.Properties.Resources.NumDownWhite;
+            this.IconSizeBottomButton.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            this.IconSizeBottomButton.FlatAppearance.BorderSize = 0;
+            this.IconSizeBottomButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.IconSizeBottomButton.Location = new System.Drawing.Point(314, 195);
+            this.IconSizeBottomButton.Name = "IconSizeBottomButton";
+            this.IconSizeBottomButton.Size = new System.Drawing.Size(16, 8);
+            this.IconSizeBottomButton.TabIndex = 55;
+            this.IconSizeBottomButton.UseVisualStyleBackColor = false;
+            this.IconSizeBottomButton.Click += new System.EventHandler(this.IconSizeBottomButton_Click);
             // 
             // pnlCustomColor1
             // 
@@ -372,6 +472,19 @@
             this.panel3.Size = new System.Drawing.Size(15, 15);
             this.panel3.TabIndex = 4;
             // 
+            // lblIconSize
+            // 
+            this.lblIconSize.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblIconSize.BackColor = System.Drawing.Color.Transparent;
+            this.lblIconSize.Font = new System.Drawing.Font("Segoe UI", 11.25F, System.Drawing.FontStyle.Bold);
+            this.lblIconSize.ForeColor = System.Drawing.Color.White;
+            this.lblIconSize.Location = new System.Drawing.Point(305, 167);
+            this.lblIconSize.Name = "lblIconSize";
+            this.lblIconSize.Size = new System.Drawing.Size(35, 25);
+            this.lblIconSize.TabIndex = 54;
+            this.lblIconSize.Text = "6";
+            this.lblIconSize.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
             // numOpacDown
             // 
             this.numOpacDown.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(31)))), ((int)(((byte)(31)))), ((int)(((byte)(31)))));
@@ -385,6 +498,21 @@
             this.numOpacDown.TabIndex = 49;
             this.numOpacDown.UseVisualStyleBackColor = false;
             this.numOpacDown.Click += new System.EventHandler(this.numOpacDown_Click);
+            // 
+            // IconSizeTopButton
+            // 
+            this.IconSizeTopButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.IconSizeTopButton.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(31)))), ((int)(((byte)(31)))), ((int)(((byte)(31)))));
+            this.IconSizeTopButton.BackgroundImage = global::client.Properties.Resources.NumUpWhite;
+            this.IconSizeTopButton.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            this.IconSizeTopButton.FlatAppearance.BorderSize = 0;
+            this.IconSizeTopButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.IconSizeTopButton.Location = new System.Drawing.Point(314, 157);
+            this.IconSizeTopButton.Name = "IconSizeTopButton";
+            this.IconSizeTopButton.Size = new System.Drawing.Size(16, 8);
+            this.IconSizeTopButton.TabIndex = 56;
+            this.IconSizeTopButton.UseVisualStyleBackColor = false;
+            this.IconSizeTopButton.Click += new System.EventHandler(this.IconSizeTopButton_Click);
             // 
             // numOpacUp
             // 
@@ -538,7 +666,7 @@
             this.pnlEnd.Controls.Add(this.cmdDelete);
             this.pnlEnd.Controls.Add(this.cmdSave);
             this.pnlEnd.Controls.Add(this.cmdExit);
-            this.pnlEnd.Location = new System.Drawing.Point(41, 756);
+            this.pnlEnd.Location = new System.Drawing.Point(41, 875);
             this.pnlEnd.Name = "pnlEnd";
             this.pnlEnd.Size = new System.Drawing.Size(482, 44);
             this.pnlEnd.TabIndex = 47;
@@ -758,7 +886,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.AutoScroll = true;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(31)))), ((int)(((byte)(31)))), ((int)(((byte)(31)))));
-            this.ClientSize = new System.Drawing.Size(574, 821);
+            this.ClientSize = new System.Drawing.Size(574, 940);
             this.Controls.Add(this.pnlShortcuts);
             this.Controls.Add(this.pnlDeleteConfo);
             this.Controls.Add(this.pictureBox2);
@@ -858,5 +986,13 @@
         private System.Windows.Forms.Panel panel3;
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.FlowLayoutPanel pnlShortcuts;
+        private System.Windows.Forms.Label IconSeparationText;
+        private System.Windows.Forms.Button IconSeparationBottomButton;
+        private System.Windows.Forms.Label lblIconSeparation;
+        private System.Windows.Forms.Button IconSeparationTopButton;
+        private System.Windows.Forms.Label IconSizeText;
+        private System.Windows.Forms.Button IconSizeBottomButton;
+        private System.Windows.Forms.Label lblIconSize;
+        private System.Windows.Forms.Button IconSizeTopButton;
     }
 }

--- a/main/Forms/frmGroup.cs
+++ b/main/Forms/frmGroup.cs
@@ -179,9 +179,9 @@ namespace client.Forms
 
             lblErrorShortcut.Visible = false; // resetting error msg
 
-            if (Category.ShortcutList.Count >= 20)
+            if (Category.ShortcutList.Count >= 50)
             {
-                lblErrorShortcut.Text = "Max 20 shortcuts in one group";
+                lblErrorShortcut.Text = "Max 50 shortcuts in one group";
                 lblErrorShortcut.BringToFront();
                 lblErrorShortcut.Visible = true;
             }

--- a/main/Forms/frmGroup.cs
+++ b/main/Forms/frmGroup.cs
@@ -85,6 +85,8 @@ namespace client.Forms
             cmdAddGroupIcon.BackgroundImage = Category.LoadIconImage();
             lblNum.Text = Category.Width.ToString();
             lblOpacity.Text = Category.Opacity.ToString();
+            lblIconSize.Text = Category.IconSize.ToString();
+            lblIconSeparation.Text = Category.Separation.ToString();
 
             if (Category.ColorString == null)  // Handles if groups is created from earlier releas w/o ColorString property
                 Category.ColorString = ColorTranslator.ToHtml(Color.FromArgb(31, 31, 31));
@@ -1196,6 +1198,72 @@ namespace client.Forms
             for(int i=0; i< pnlShortcuts.Controls.Count; i++)
             {
                 ((ucProgramShortcut)pnlShortcuts.Controls[i]).ucProgramShortcut_ReadjustArrows(i);
+            }
+        }
+
+        // Icon size
+        private void IconSizeTopButton_Click(object sender, EventArgs e)
+        {
+            int iconSize = int.Parse(lblIconSize.Text);
+            iconSize += 1;
+            Category.IconSize = iconSize;
+            lblIconSize.Text = iconSize.ToString();
+            IconSizeBottomButton.Enabled = true;
+            IconSizeBottomButton.BackgroundImage = global::client.Properties.Resources.NumDownWhite;
+
+            if (iconSize > 255)
+            {
+                IconSizeTopButton.Enabled = false;
+                IconSizeTopButton.BackgroundImage = global::client.Properties.Resources.NumUpGray;
+            }
+        }
+
+        private void IconSizeBottomButton_Click(object sender, EventArgs e)
+        {
+            int iconSize = int.Parse(lblIconSize.Text);
+            iconSize -= 1;
+            Category.IconSize = iconSize;
+            lblIconSize.Text = iconSize.ToString();
+            IconSizeTopButton.Enabled = true;
+            IconSizeTopButton.BackgroundImage = global::client.Properties.Resources.NumUpWhite;
+
+            if (iconSize < 11)
+            {
+                IconSizeBottomButton.Enabled = false;
+                IconSizeBottomButton.BackgroundImage = global::client.Properties.Resources.NumDownGray;
+            }
+        }
+
+        // Icon separation
+        private void IconSeparationTopButton_Click(object sender, EventArgs e)
+        {
+            int separation = int.Parse(lblIconSeparation.Text);
+            separation += 1;
+            Category.Separation = separation;
+            lblIconSeparation.Text = separation.ToString();
+            IconSeparationBottomButton.Enabled = true;
+            IconSeparationBottomButton.BackgroundImage = global::client.Properties.Resources.NumDownWhite;
+
+            if (separation > 49)
+            {
+                IconSeparationTopButton.Enabled = false;
+                IconSeparationTopButton.BackgroundImage = global::client.Properties.Resources.NumUpGray;
+            }
+        }
+
+        private void IconSeparationBottomButton_Click(object sender, EventArgs e)
+        {
+            int separation = int.Parse(lblIconSeparation.Text);
+            separation -= 1;
+            Category.Separation = separation;
+            lblIconSeparation.Text = separation.ToString();
+            IconSeparationTopButton.Enabled = true;
+            IconSeparationTopButton.BackgroundImage = global::client.Properties.Resources.NumUpWhite;
+
+            if (separation < 2)
+            {
+                IconSeparationBottomButton.Enabled = false;
+                IconSeparationBottomButton.BackgroundImage = global::client.Properties.Resources.NumDownGray;
             }
         }
     }


### PR DESCRIPTION
This is the continuation of #35 

Remaining: 

- [x] Add settings for changing values
- [x] Test with different icon sizes and separation when there are settings. 

@PikeNote what was the issue with DPI? I don't have to save settings to have the new DPI's, at least with this PR.

100% DPI:
![imagen](https://user-images.githubusercontent.com/11770760/216765273-0530c911-c9cf-4378-82f0-98b07c97a646.png)

175% DPI:
![imagen](https://user-images.githubusercontent.com/11770760/216765258-49a45c3a-c50a-4cc2-b643-3830b464100a.png)

I don't have more time now to adding the settings. Maybe tomorrow, if not then probably have to wait to next weekend.